### PR TITLE
[chat]OpenAPIからのレスポンスがエラーだと例外発生して落ちてしまうのを修正

### DIFF
--- a/src/modules/open_ai.ts
+++ b/src/modules/open_ai.ts
@@ -13,7 +13,7 @@ type ChatOption = {
 
 export const createCompletion = async (prompt: string, option: ChatOption) => {
   const completion = await openai.createChatCompletion({
-    model: 'gpt-3.5-turbo',
+    model: option.model || 'gpt-3.5-turbo',
     messages: [
       {
         role: 'system',

--- a/src/modules/open_ai.ts
+++ b/src/modules/open_ai.ts
@@ -26,5 +26,12 @@ export const createCompletion = async (prompt: string, option: ChatOption) => {
       }
     ]
   })
-  return completion.data.choices[0].message
+    .then((completion) => completion.data.choices[0].message)
+    .catch((e) => (console.log({
+      content: null,
+      status: e.response.status,
+      statusText: e.response.statusText,
+      message: e.response.data.error.message
+    })))
+  return completion
 }


### PR DESCRIPTION
内部で使用されているaxiosが400系が返ってきたときに例外発生するので、それを `catch` してログを吐くように修正しました。
ついでに、`chat4` で `gpt-4` が選択されるはずだったのが、そうなってなかったのでそちらも修正しました。