### PR TITLE
[play/stop]オーディオプレイヤー回りを調整

### DIFF
--- a/src/commands/play.ts
+++ b/src/commands/play.ts
@@ -7,7 +7,6 @@ import ytdl from 'ytdl-core'
 
 import { youtubeSearch, getWatchUrl } from '../modules/google_api'
 import { handleSummon } from './summon'
-import { killMyself } from './utils/kill_myself'
 import { store } from '../modules/store'
 
 const getYoutubeStream = (url: string) => {
@@ -20,16 +19,18 @@ export const handlePlay = async (message: Message<boolean>, subTokens: string[])
     return
   }
 
-  // 一度自信を切断し、再召喚する
-  const didDisconnect = killMyself(guild)
-  if (!didDisconnect) {
-    handleSummon(message)
+  // ボイスチャンネルにいなければ召喚する
+  const connection = getVoiceConnection(guild.id) ?? await handleSummon(message)
+
+  // 再生済みであれば一度停止する
+  const prevPlayer = store.players.get(guild.id)
+  if (prevPlayer) {
+    prevPlayer.stop()
   }
 
-  const player = createAudioPlayer()
-
+  // コマンド引数をもとに音源を選択する
   const input = await match(subTokens)
-    .when((tokens) => tokens.length === 0, () => path.join(__dirname, '../default.mp3'))
+    .when((tokens) => tokens.length === 0, () => path.join(__dirname, '../../default.mp3'))
     .when((tokens) => tokens.length === 1 && tokens[0].startsWith('http'), (tokens) => getYoutubeStream(tokens[0]))
     .when((tokens) => tokens.length > 0, async (tokens) => {
       const query = tokens.join(' ')
@@ -38,24 +39,31 @@ export const handlePlay = async (message: Message<boolean>, subTokens: string[])
         return null
       }
       const url = getWatchUrl(res.videoId)
-      getYoutubeStream(url)
+      return getYoutubeStream(url)
     })
     .otherwise(() => null)
 
+  // 該当する音源が存在しなければなにもしない
   if (!input) {
     return
   }
 
+  // 音量調整可能な状態で、音源をもとにオーディオリソースを作成
   const resource = createAudioResource(input, {
     inlineVolume: true
   })
 
+  // オーディオプレイヤーを作成
+  // 停止用にオーディオプレイヤーはサーバーIDをキーに保存
+  const player = createAudioPlayer()
+  store.players.set(guild.id, player)
+
+  // 音量を0.1に調整し、再生する
   resource.volume?.setVolume(0.1)
   player.play(resource)
 
-  if (message.guild === null) return
-  const connection = getVoiceConnection(message.guild.id)
+  // ボイスチャンネルから購読する
   connection?.subscribe(player)
-  store.players.push(player)
+
   return player
 }

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,10 +1,17 @@
-import { AudioPlayer } from '@discordjs/voice'
 import { Message } from 'discord.js'
 import { store } from '../modules/store'
 
 export const handleStop = (message: Message) => {
-  const players = store.players
-  players.forEach((player: AudioPlayer) => {
-    player.stop()
-  })
+  const guild = message.guild
+  if (!guild) {
+    return false
+  }
+
+  const player = store.players.get(guild.id)
+  if (!player) {
+    return false
+  }
+
+  player.stop()
+  store.players.delete(guild.id)
 }

--- a/src/commands/summon.ts
+++ b/src/commands/summon.ts
@@ -10,5 +10,5 @@ export const handleSummon = async (message: Message<boolean>) => {
     })
     return
   }
-  summon(member)
+  return summon(member)
 }

--- a/src/commands/utils/summon.ts
+++ b/src/commands/utils/summon.ts
@@ -6,13 +6,12 @@ export const summon = (member: GuildMember) => {
   const voiceChannel = member?.voice.channel
 
   if (!voiceChannel) {
-    return false
+    return null
   }
 
-  joinVoiceChannel({
+  return joinVoiceChannel({
     channelId: voiceChannel.id,
     guildId: voiceChannel.guild.id,
     adapterCreator: voiceChannel.guild.voiceAdapterCreator
   })
-  return true
 }

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -1,5 +1,7 @@
 import { AudioPlayer } from '@discordjs/voice'
 
+type guildId = string;
+
 export const store = {
-  players: [] as AudioPlayer[]
+  players: new Map() as Map<guildId, AudioPlayer>
 }


### PR DESCRIPTION
- デフォルト再生のファイルパスが変更されたので修正しました
- YouTubeから検索する必要がある場合のストリームを正しく返せていなかったので修正しました
- サーバーごとに停止できるように修正しました
- 多重に再生した際に過去に再生していたものを停止するようにしました
- ボイスチャンネルにおらず、召喚してから再生するときの挙動を修正しました